### PR TITLE
chore: add start model api support

### DIFF
--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -2,20 +2,26 @@
 
 import OpenAI from 'openai';
 
-// gets API Key from environment variable OPENAI_API_KEY
-const openai = new OpenAI();
+const openai = new OpenAI({
+  baseURL: 'http://localhost:7331',
+  apiKey: 'cortex',
+});
+
+const model = 'TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF';
 
 async function main() {
+  await openai.models.start(model);
+
   // Non-streaming:
   const completion = await openai.chat.completions.create({
-    model: 'gpt-4',
+    model,
     messages: [{ role: 'user', content: 'Say this is a test' }],
   });
   console.log(completion.choices[0]?.message?.content);
 
   // Streaming:
   const stream = await openai.chat.completions.create({
-    model: 'gpt-4',
+    model,
     messages: [{ role: 'user', content: 'Say this is a test' }],
     stream: true,
   });

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "openai",
+  "name": "@janhq/openai-node",
   "version": "4.47.1",
-  "description": "The official TypeScript library for the OpenAI API",
-  "author": "OpenAI <support@openai.com>",
+  "description": "Forked version of the OpenAI Node.js client library",
+  "author": "Jan <service@jan.ai>",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
   "type": "commonjs",
-  "repository": "github:openai/openai-node",
+  "repository": "github:janhq/cortex-node",
   "license": "Apache-2.0",
   "packageManager": "yarn@1.22.22",
   "files": [

--- a/src/resources/models.ts
+++ b/src/resources/models.ts
@@ -29,6 +29,13 @@ export class Models extends APIResource {
   del(model: string, options?: Core.RequestOptions): Core.APIPromise<ModelDeleted> {
     return this._client.delete(`/models/${model}`, options);
   }
+
+   /**
+   * Start a model instance, providing basic information about the model such as the
+   */
+   start(model: string, options?: Core.RequestOptions): Core.APIPromise<Model> {
+    return this._client.post(`/models/${model}/start`, options);
+  }
 }
 
 /**


### PR DESCRIPTION
```ts
import { Cortex } from '@janhq/cortex-node';

const cortex = new Cortex({
  baseURL: 'http://localhost:7331',
  apiKey: 'cortex',
});

cortex.models.start('llama3:7b')
cortex.models.stop('llama3:7b')
cortex.threads.list()
```